### PR TITLE
Fixed StorageWindow Prefs Value Cast

### DIFF
--- a/Editor/StorageSystem/StorageWindow.cs
+++ b/Editor/StorageSystem/StorageWindow.cs
@@ -89,7 +89,8 @@ namespace StarSmithGames.Core.Editor.StorageSystem
 							var key = keys[i].Split("_h")[0];
 							if (PlayerPrefs.HasKey(key))
 							{
-								prefs.Add(key, PlayerPrefs.GetString(key));
+								var isString = !PlayerPrefs.GetString(key).IsEmpty();
+								prefs.Add(key, isString ? PlayerPrefs.GetString(key) : registry.GetValue(keys[i]).ToString());
 							}
 						}
 					}


### PR DESCRIPTION
PlayerPrefs has only int float and string types. Registry GetValue can help with float and int types.